### PR TITLE
fix 405 error after signing up an event

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,11 +7,13 @@ RewriteEngine On
 
 # Disallows others to look directly into /public/ folder
 Options -Indexes
-DirectorySlash Off 
 
 # When using the script within a sub-folder, put this path here, like /mysubfolder/
 # If your app is in the root of your web folder, then leave it commented out
 RewriteBase /db_proj_2018/
+
+# remove trailing slash and "index" from url
+RewriteRule ^/?(.*)/(index)?$   $1   [R,L]
 
 # General rewrite rules
 RewriteCond %{REQUEST_FILENAME} !-d
@@ -19,12 +21,21 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-l
 
 RewriteRule ^(.+)$ index.php?url=$1 [QSA,L]
+
+# hide sensitive or unrelated folders
 RewriteRule ^/?application.* index.php?url=problem
 RewriteRule ^/?\.git.* index.php?url=problem
 RewriteRule ^/?_install index.php?url=problem
 
+# hide sensitive or unrelated files
 RewriteRule ^/?Dockerfile index.php?url=problem
-RewriteRule ^(/?|.+/)\.ht.* index.php?url=problem
+RewriteRule ^(/?|.+/)\.ht.* index.php?url=problem [R=403]
 
+# make error page more nice looking
 ErrorDocument 403 /db_proj_2018/index.php?url=problem
 ErrorDocument 500 /db_proj_2018/index.php?url=problem
+
+# don't add trailing slash to url
+<FilesMatch "^(?!db_proj_2018)">
+  DirectorySlash off
+</FilesMatch>


### PR DESCRIPTION
在活動列表的頁面裡，按下 signup 連結，並輸入隊名後按下第一個 submit，會回到活動列表。
然而在這個時候，在按下其他活動的 signup 時，會出現「方法不允許」的錯誤。
我的處理方法是，利用 mod_rewrite，把網址末端出現的斜線「/」和「/index」移除掉